### PR TITLE
Update Autocomplete.global.vue

### DIFF
--- a/src/components/Autocomplete/Autocomplete.global.vue
+++ b/src/components/Autocomplete/Autocomplete.global.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="autocomplete md:block md:mr-0 mr-3 relative w-fit">
+  <div class="autocomplete md:block md:mr-0 mr-3 relative w-[500px]">
     <div
       class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none"
     >


### PR DESCRIPTION
Added width to the search bar (w-[500px]) at the front page to fix the issue that long names in the dropdown are not visible in their full length.
I tested this locally and it worked (screenshot). However, I'm confused by the many branches in this repository, I don't know which one is deployed by Github Pages.
<img width="1242" height="748" alt="grafik" src="https://github.com/user-attachments/assets/2ae4a3a0-9354-4fcc-942a-c5a6952058c8" />
