### PR TITLE
style adjustments for ProjectStats

### DIFF
--- a/src/components/ProjectStats.global.vue
+++ b/src/components/ProjectStats.global.vue
@@ -6,7 +6,8 @@
       :value="value"
     >
       <span>
-        {{ type }}: {{ value }}{{ index < list.length - 1 ? '; ' : '' }}
+         <span style="font-weight: 700;" class="capitalize">{{ type }}:</span>
+        {{ value }}{{ index < list.length - 1 ? '; ' : '' }}
       </span>
     </slot>
   </component>


### PR DESCRIPTION
This makes the labels bold while the numbers stay normal (for the project stats e.g. on the home page)
this:
Valid Species: 20.208; taxon names: 31.507; collection objects: 25.408; project sources: 7.203; images: 772; biological associations: 2.830